### PR TITLE
Added "path check"

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,10 @@ function base64ToImage(base64Str, path, optionalObj) {
         fileName = fileName + '.' + imageType;
     }
 
+    if (path == ".") {
+        path = "./"
+    }
+
     abs = path + fileName;
     fs.writeFile(abs, imageBuffer.data, 'base64', function(err) {
         if (err && optionalObj.debug) {


### PR DESCRIPTION
Before this modification, When `path=="."`, it creates a hidden file which has a name starts with `.`, even though  optionalObject doesn't tells the filename so.

This change solves that problem, and makes the name of image as specified by optionalObj.